### PR TITLE
Forcing manual deploy run to enable it

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,16 +1,18 @@
-name: Manual Full Deployment (Forced Build & Deploy)
+name: Manual Deployment
+
+# This workflow allows for manual deployment of both frontend and backend services.
+# In the case that developers need to force a deployment
+# they can trigger this workflow from the GitHub Actions tab.
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       stack:
         description: "Pulumi Stack Name (e.g., dev, staging, prod)"
         required: true
         default: "dev"
-      tag:
-        description: "Optional: Docker Tag / Image Version (defaults to current SHA)"
-        required: false
-        default: ${{ github.sha }}
 
 env:
   GCP_PROJECT_ID: jrw-demo-project

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -15,7 +15,7 @@ gcp_config = Config("gcp")
 region = gcp_config.require('region') or "us-central1"
 project = gcp_config.require("project")
 
-project_number = projects.get_project().number
+project_number = projects.get_project(filter=f"id:{project}").number
 
 backend_service = cloudrun.Service(
     "backend-service",


### PR DESCRIPTION
Apparently this is a known issue. Can't have workflow_dispatch without first having an event trigger it.